### PR TITLE
FIX(ci): Use maintained base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # GENERATED!, if you want to modify this, modify the file in `niomon-common-files` project
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG THIRD_PARTY_LIB
 ARG PROJECT_LIB
 ARG JAR_FILE


### PR DESCRIPTION
This is part of the CVE-2022-2068 fixes.
ubirch/java has not been updated in years.
Switching to the Amazon corretto build of Java 8.

See: OPS-577